### PR TITLE
Add simple kakeibo app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+kakeibo.json

--- a/README.md
+++ b/README.md
@@ -1,2 +1,25 @@
-#コーデックス‐20250604
+# コーデックス‐20250604
 ここにプロジェクトの説明を書きます。
+
+## 家計簿アプリ
+`kakeibo.py` は簡単な家計簿アプリです。Python3 が実行できる環境で以下のように使います。
+
+### 使い方
+- 収入を追加する
+  ```bash
+  python3 kakeibo.py add -t income -a 50000 -c salary -d "給与"
+  ```
+- 支出を追加する
+  ```bash
+  python3 kakeibo.py add -t expense -a 2000 -c food -d "ランチ"
+  ```
+- 記録を一覧表示する
+  ```bash
+  python3 kakeibo.py list
+  ```
+- 収支を確認する
+  ```bash
+  python3 kakeibo.py balance
+  ```
+
+記録は `kakeibo.json` というファイルに保存されます。

--- a/kakeibo.py
+++ b/kakeibo.py
@@ -1,0 +1,86 @@
+import argparse
+import json
+import os
+from datetime import datetime
+
+DATA_FILE = 'kakeibo.json'
+
+
+def load_records():
+    if not os.path.exists(DATA_FILE):
+        return []
+    with open(DATA_FILE, 'r', encoding='utf-8') as f:
+        try:
+            return json.load(f)
+        except json.JSONDecodeError:
+            return []
+
+
+def save_records(records):
+    with open(DATA_FILE, 'w', encoding='utf-8') as f:
+        json.dump(records, f, ensure_ascii=False, indent=2)
+
+
+def add_record(args):
+    records = load_records()
+    record = {
+        'date': datetime.now().isoformat(timespec='seconds'),
+        'type': args.type,
+        'category': args.category,
+        'description': args.description,
+        'amount': args.amount,
+    }
+    records.append(record)
+    save_records(records)
+    print('Record added.')
+
+
+def list_records(args):
+    records = load_records()
+    if not records:
+        print('No records found.')
+        return
+    for r in records:
+        print(f"{r['date']} | {r['type']} | {r['category']} | {r['description']} | {r['amount']}")
+
+
+def show_balance(args):
+    records = load_records()
+    income = sum(r['amount'] for r in records if r['type'] == 'income')
+    expense = sum(r['amount'] for r in records if r['type'] == 'expense')
+    balance = income - expense
+    print(f"Income: {income}")
+    print(f"Expense: {expense}")
+    print(f"Balance: {balance}")
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description='Simple Kakeibo (household ledger)')
+    subparsers = parser.add_subparsers(dest='command')
+
+    add_p = subparsers.add_parser('add', help='Add a record')
+    add_p.add_argument('-t', '--type', choices=['income', 'expense'], required=True, help='Record type')
+    add_p.add_argument('-a', '--amount', type=float, required=True, help='Amount')
+    add_p.add_argument('-c', '--category', default='', help='Category')
+    add_p.add_argument('-d', '--description', default='', help='Description')
+    add_p.set_defaults(func=add_record)
+
+    list_p = subparsers.add_parser('list', help='List records')
+    list_p.set_defaults(func=list_records)
+
+    bal_p = subparsers.add_parser('balance', help='Show balance summary')
+    bal_p.set_defaults(func=show_balance)
+
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    if not hasattr(args, 'func'):
+        print('No command given. Use -h for help.')
+        return
+    args.func(args)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add a Python household ledger script `kakeibo.py`
- update README with usage instructions
- ignore generated data files

## Testing
- `python3 -m py_compile kakeibo.py`
- `python3 kakeibo.py add -t income -a 1000 -c test -d test_entry`

------
https://chatgpt.com/codex/tasks/task_e_6846d09d5858832cb1dc250b79d265fd